### PR TITLE
Fix failing Redis test

### DIFF
--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -34,8 +34,6 @@ class ThrottleRequestsWithRedisTest extends TestCase
 
             Carbon::setTestNow($now);
 
-            resolve('redis')->flushAll();
-
             Route::get('/', function () {
                 return 'yes';
             })->middleware(ThrottleRequestsWithRedis::class.':2,1');


### PR DESCRIPTION
For some unexplainable reason this line caused the build to fail with the following exception message:

> Cannot use 'FLUSHALL' over clusters of connections.

By removing it everything works fine. Nothing in the upstream dependencies or on Laravel itself has changes that could explain causing this.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
