### PR TITLE
[5.8] remove extra check for the method

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -35,8 +35,7 @@ trait AuthenticatesUsers
         // If the class is using the ThrottlesLogins trait, we can automatically throttle
         // the login attempts for this application. We'll key this by the username and
         // the IP address of the client making these requests into this application.
-        if (method_exists($this, 'hasTooManyLoginAttempts') &&
-            $this->hasTooManyLoginAttempts($request)) {
+        if ($this->hasTooManyLoginAttempts($request)) {
             $this->fireLockoutEvent($request);
 
             return $this->sendLockoutResponse($request);


### PR DESCRIPTION
It seems that there is no need to check for the existence of `hasTooManyLoginAttempts` method, since the `ThrottlesLogins` trait contains that method and is already used on the `AuthenticatesUsers` trait. I wonder if there is any way to remove that trait, making the method to be absent.

